### PR TITLE
harden: this pnpm workspace configuration does not set ... in...

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -10,8 +10,6 @@ packages:
   - 'landing'
   - '!**/test/**'
 minimumReleaseAge: 10080
-blockExoticSubdeps: true
-trustPolicy: no-downgrade
 allowBuilds:
   '@swc/core': set this to true or false
   core-js: set this to true or false

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -9,6 +9,9 @@ packages:
   - 'e2e/*'
   - 'landing'
   - '!**/test/**'
+minimumReleaseAge: 10080
+blockExoticSubdeps: true
+trustPolicy: no-downgrade
 allowBuilds:
   '@swc/core': set this to true or false
   core-js: set this to true or false


### PR DESCRIPTION
## Summary
  Harden `pnpm-workspace.yaml` (flagged by semgrep): raise pnpm's minimum release age from its 1-day default to 7 days.

  ## Vulnerability
  | Field | Value |
  |-------|-------|
  | **ID** | package_managers.pnpm.pnpm-missing-minimum-release-age.pnpm-minimum-release-age |
  | **Severity** | HIGH |
  | **Scanner** | semgrep |
  | **File** | `pnpm-workspace.yaml` |

  pnpm 11 already defaults `minimumReleaseAge` to `1440` minutes (1 day). This PR raises it to `10080` minutes (7 days).

  ## Why 7 days
  Most supply-chain compromises are caught and unpublished within days of release. A 7-day window gives the community time to flag and yank a malicious or broken package before it ever reaches an install here, while still keeping dependency updates reasonably current.

  ## Threat Model Context
  Corrected from the original description: crossbind is not a private application — this monorepo publishes 100+ npm packages. `minimumReleaseAge` protects contributors, CI, and downstream consumers who build from this repo from newly published, unvetted dependency 
  versions.

  ## Changes
  - `pnpm-workspace.yaml`: `minimumReleaseAge: 10080`
  
  ## Scope note
  This PR originally also enabled `blockExoticSubdeps: true` and `trustPolicy: no-downgrade`. Per review feedback, both are removed here:
  - `trustPolicy: no-downgrade` broke `pnpm install --frozen-lockfile` today with `ERR_PNPM_TRUST_DOWNGRADE` on `ast-v8-to-istanbul@1.0.2`, `semver@6.3.1`, and `undici-types@6.20.0`.
  - `blockExoticSubdeps` already defaults to `true` in pnpm 11 and the repo has no exotic dependency specs, so it was redundant.
---
*This patch removes an exploit primitive — a code pattern that, while not independently exploitable today, could be chained with other weaknesses by automated exploit-development tooling. Proactive removal of such primitives raises the bar against increasingly capable automated attack tools.*

---
*Automated security fix by [OrbisAI Security](https://orbisappsec.com)*
