### PR TITLE
fix(release): carry the plan between jobs compressed

### DIFF
--- a/.github/workflows/release-crossbind.yml
+++ b/.github/workflows/release-crossbind.yml
@@ -28,7 +28,7 @@ jobs:
         name: Plan npm package train
         runs-on: ubuntu-24.04
         outputs:
-            planBase64: ${{ steps.plan.outputs.planBase64 }}
+            planGzipBase64: ${{ steps.plan.outputs.planGzipBase64 }}
             packageCount: ${{ steps.plan.outputs.packageCount }}
             hasLinux: ${{ steps.plan.outputs.hasLinux }}
             linuxShards: ${{ steps.plan.outputs.linuxShards }}
@@ -114,8 +114,8 @@ jobs:
               run: pnpm install --frozen-lockfile
             - name: Restore the approved plan
               env:
-                  RELEASE_PLAN_BASE64: ${{ needs.plan.outputs.planBase64 }}
-              run: node -e 'require("node:fs").writeFileSync(process.argv[1], Buffer.from(process.env.RELEASE_PLAN_BASE64, "base64"))' "$RUNNER_TEMP/workspace-release-plan.json"
+                  RELEASE_PLAN_GZIP_BASE64: ${{ needs.plan.outputs.planGzipBase64 }}
+              run: node scripts/release/restore-workspace-plan.mjs "$RUNNER_TEMP/workspace-release-plan.json"
             - name: Build every selected Linux artifact before publication
               run: |
                   node scripts/release/build-workspace-artifacts.mjs \
@@ -152,8 +152,8 @@ jobs:
               run: pnpm install --frozen-lockfile
             - name: Restore the approved plan
               env:
-                  RELEASE_PLAN_BASE64: ${{ needs.plan.outputs.planBase64 }}
-              run: node -e 'require("node:fs").writeFileSync(process.argv[1], Buffer.from(process.env.RELEASE_PLAN_BASE64, "base64"))' "$RUNNER_TEMP/workspace-release-plan.json"
+                  RELEASE_PLAN_GZIP_BASE64: ${{ needs.plan.outputs.planGzipBase64 }}
+              run: node scripts/release/restore-workspace-plan.mjs "$RUNNER_TEMP/workspace-release-plan.json"
             - name: Build every selected iOS artifact before publication
               run: |
                   node scripts/release/build-workspace-artifacts.mjs \
@@ -198,8 +198,8 @@ jobs:
               run: pnpm install --frozen-lockfile
             - name: Restore the approved plan
               env:
-                  RELEASE_PLAN_BASE64: ${{ needs.plan.outputs.planBase64 }}
-              run: node -e 'require("node:fs").writeFileSync(process.argv[1], Buffer.from(process.env.RELEASE_PLAN_BASE64, "base64"))' "$RUNNER_TEMP/workspace-release-plan.json"
+                  RELEASE_PLAN_GZIP_BASE64: ${{ needs.plan.outputs.planGzipBase64 }}
+              run: node scripts/release/restore-workspace-plan.mjs "$RUNNER_TEMP/workspace-release-plan.json"
             - name: Restore Linux artifacts
               if: ${{ needs.plan.outputs.hasLinux == 'true' }}
               uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
@@ -275,8 +275,8 @@ jobs:
               run: pnpm install --frozen-lockfile
             - name: Restore the approved plan
               env:
-                  RELEASE_PLAN_BASE64: ${{ needs.plan.outputs.planBase64 }}
-              run: node -e 'require("node:fs").writeFileSync(process.argv[1], Buffer.from(process.env.RELEASE_PLAN_BASE64, "base64"))' "$RUNNER_TEMP/workspace-release-plan.json"
+                  RELEASE_PLAN_GZIP_BASE64: ${{ needs.plan.outputs.planGzipBase64 }}
+              run: node scripts/release/restore-workspace-plan.mjs "$RUNNER_TEMP/workspace-release-plan.json"
             - name: Restore the complete approved train
               uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
               with:

--- a/docs/CODEMAP.md
+++ b/docs/CODEMAP.md
@@ -252,6 +252,7 @@ To add a new `ports/<X>`: see `docs/playbooks/new-port.md` (uses `ports/zlib` as
 | `release/package-crossbind.mjs` | CLI entrypoint for exact tarball creation and smoke validation |
 | `release/workspace-release.mjs` | Discover public workspaces, select channel bumps and derive platform/dependency order |
 | `release/plan-workspace-release.mjs` | Registry-read-only release-train planner |
+| `release/restore-workspace-plan.mjs` | Write the compressed plan job output back to a file for build and publish jobs |
 | `release/build-workspace-artifacts.mjs` | Build and pack the Linux or macOS side of an approved train |
 | `release/assemble-workspace-artifacts.mjs` | Refuse incomplete artifact sets and merge the one multi-platform package |
 | `release/publish-workspace-release.mjs` | OIDC publish/reuse in dependency order, provenance verification and exact package tags |

--- a/scripts/release/plan-workspace-release.mjs
+++ b/scripts/release/plan-workspace-release.mjs
@@ -6,7 +6,7 @@ import path from 'node:path';
 import { execFileSync } from 'node:child_process';
 import { fileURLToPath } from 'node:url';
 import { appendGitHubOutput, writeJson } from './release-lib.mjs';
-import { buildWorkspaceReleasePlan } from './workspace-release.mjs';
+import { buildWorkspaceReleasePlan, encodeWorkspacePlanOutput } from './workspace-release.mjs';
 
 const REPOSITORY_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..', '..');
 const valueOf = (name) => {
@@ -24,9 +24,9 @@ if (process.argv.includes('--require-changes') && plan.packageCount === 0) {
     throw new Error(`No ${channel} package versions require publication; refusing an empty writing release.`);
 }
 writeJson(output, plan);
-const encoded = fs.readFileSync(output).toString('base64');
+const encoded = encodeWorkspacePlanOutput(fs.readFileSync(output));
 appendGitHubOutput(githubOutput, {
-    planBase64: encoded,
+    planGzipBase64: encoded,
     packageCount: plan.packageCount,
     hasLinux: plan.linuxShards.length > 0,
     linuxShards: JSON.stringify(plan.linuxShards),

--- a/scripts/release/restore-workspace-plan.mjs
+++ b/scripts/release/restore-workspace-plan.mjs
@@ -1,0 +1,12 @@
+#!/usr/bin/env node
+
+import fs from 'node:fs';
+import path from 'node:path';
+import { decodeWorkspacePlanOutput } from './workspace-release.mjs';
+
+const target = process.argv[2];
+const encoded = process.env.RELEASE_PLAN_GZIP_BASE64;
+if (!target) throw new Error('restore-workspace-plan: a target path is required.');
+if (!encoded) throw new Error('restore-workspace-plan: RELEASE_PLAN_GZIP_BASE64 is empty; the plan job output did not arrive.');
+fs.mkdirSync(path.dirname(target), { recursive: true });
+fs.writeFileSync(target, decodeWorkspacePlanOutput(encoded));

--- a/scripts/release/test/actionlint.test.mjs
+++ b/scripts/release/test/actionlint.test.mjs
@@ -178,3 +178,11 @@ test('every external action in every repository workflow is pinned to a full com
         for (const action of actions) assert.match(action, /^[^@\s]+@[0-9a-f]{40}$/, `${workflow}: ${action} is not commit-pinned`);
     }
 });
+
+test('the release workflow hands the plan to every job through the compressed output', () => {
+    const source = fs.readFileSync(path.join(ROOT, '.github', 'workflows', 'release-crossbind.yml'), 'utf8');
+    assert.doesNotMatch(source, /planBase64|RELEASE_PLAN_BASE64/);
+    assert.match(source, /planGzipBase64: \$\{\{ steps\.plan\.outputs\.planGzipBase64 \}\}/);
+    assert.equal(source.match(/RELEASE_PLAN_GZIP_BASE64: \$\{\{ needs\.plan\.outputs\.planGzipBase64 \}\}/g)?.length, 4);
+    assert.equal(source.match(/node scripts\/release\/restore-workspace-plan\.mjs "\$RUNNER_TEMP\/workspace-release-plan\.json"/g)?.length, 4);
+});

--- a/scripts/release/test/workspace-release.test.mjs
+++ b/scripts/release/test/workspace-release.test.mjs
@@ -3,6 +3,7 @@ import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
 import test from 'node:test';
+import { execFileSync } from 'node:child_process';
 import { fileURLToPath } from 'node:url';
 import {
     buildWorkspaceReleasePlan,
@@ -10,6 +11,8 @@ import {
     discoverPublishablePackages,
     provenanceCommitFromBundle,
     readTrainVersion,
+    decodeWorkspacePlanOutput,
+    encodeWorkspacePlanOutput,
 } from '../workspace-release.mjs';
 import { setWorkspaceVersion } from '../set-workspace-version.mjs';
 
@@ -322,4 +325,57 @@ test('scoped npm provenance resolves only the canonical workflow commit', () => 
     };
     assert.equal(provenanceCommitFromBundle(bundle, '@crossbind/plugin-vite', '2.0.0-beta.54'), COMMIT);
     assert.equal(provenanceCommitFromBundle(bundle, '@crossbind/plugin-rollup', '2.0.0-beta.54'), null);
+});
+
+test('the plan travels between jobs compressed and stays far below the Linux environment limit', () => {
+    const entry = {
+        name: '@crossbind/port-example-android',
+        version: '2.0.0-beta.55',
+        path: 'ports/example/android',
+        manifestPath: 'ports/example/android/package.json',
+        channel: 'beta',
+        npmDistTag: 'beta',
+        prerelease: true,
+        gitTag: '@crossbind/port-example-android@2.0.0-beta.55',
+        buildKind: 'android',
+        prepublishOnly: 'crossbind build -p android',
+        localDependencies: { '@crossbind/port-example': 'workspace:^', crossbind: 'workspace:^' },
+        runtimeLocalDependencies: ['@crossbind/port-example'],
+        publishLocalDependencies: ['@crossbind/port-example', 'crossbind'],
+        reason: 'version-bump',
+    };
+    const packages = Array.from({ length: 250 }, (_, index) => ({ ...entry, name: `${entry.name}-${index}` }));
+    const plan = {
+        schemaVersion: 1,
+        packages,
+        publishOrder: packages.map((item) => item.name),
+        workspacePackages: Object.fromEntries(packages.map((item) => [item.name, item])),
+    };
+    const text = `${JSON.stringify(plan, null, 2)}\n`;
+
+    const encoded = encodeWorkspacePlanOutput(text);
+
+    assert.match(encoded, /^[A-Za-z0-9+/]+=*$/);
+    assert.ok(encoded.length < 65536, `encoded plan is ${encoded.length} bytes`);
+    assert.ok(text.length > 131072, 'the fixture must exceed the raw limit to prove the point');
+    assert.equal(decodeWorkspacePlanOutput(encoded).toString('utf8'), text);
+});
+
+test('the restore script writes the exact plan bytes from the job output environment', () => {
+    const directory = fs.mkdtempSync(path.join(os.tmpdir(), 'crossbind-plan-restore-'));
+    const target = path.join(directory, 'workspace-release-plan.json');
+    const text = '{\n  "schemaVersion": 1\n}\n';
+    execFileSync(process.execPath, [path.join(ROOT, 'scripts', 'release', 'restore-workspace-plan.mjs'), target], {
+        env: { ...process.env, RELEASE_PLAN_GZIP_BASE64: encodeWorkspacePlanOutput(text) },
+    });
+    assert.equal(fs.readFileSync(target, 'utf8'), text);
+    assert.throws(
+        () =>
+            execFileSync(process.execPath, [path.join(ROOT, 'scripts', 'release', 'restore-workspace-plan.mjs'), target], {
+                env: { ...process.env, RELEASE_PLAN_GZIP_BASE64: '' },
+                stdio: 'pipe',
+            }),
+        /RELEASE_PLAN_GZIP_BASE64/,
+    );
+    fs.rmSync(directory, { recursive: true, force: true });
 });

--- a/scripts/release/workspace-release.mjs
+++ b/scripts/release/workspace-release.mjs
@@ -1,5 +1,6 @@
 import fs from 'node:fs';
 import path from 'node:path';
+import zlib from 'node:zlib';
 import { loadReleaseNotes, semverChannelPolicy } from './release-lib.mjs';
 
 export const WORKSPACE_REPOSITORY = 'https://github.com/crossbind/crossbind.git';
@@ -548,4 +549,15 @@ export function validateWorkspaceReleasePlan(plan, { root } = {}) {
         }
     }
     return plan;
+}
+
+// The plan reaches every build and publish job as one job output injected into an environment
+// variable. Linux refuses a single variable above 128 KiB and a repository-wide train is well past
+// that as plain base64, so the output carries the gzip-compressed bytes instead.
+export function encodeWorkspacePlanOutput(text) {
+    return zlib.gzipSync(Buffer.from(text)).toString('base64');
+}
+
+export function decodeWorkspacePlanOutput(encoded) {
+    return zlib.gunzipSync(Buffer.from(encoded, 'base64'));
 }


### PR DESCRIPTION
The plan job output is injected into every build and publish step as one environment variable. A repository-wide train's plan is 287 KB as base64, past the 128 KiB Linux limit for a single variable, so every Linux job died with "Argument list too long" while macOS passed. Ship the plan gzip-compressed (12 KB for 107 packages) and restore it through a script that fails loudly when the output is missing.