### PR TITLE
fix(create-crossbind): let pnpm build wrangler's native helpers

### DIFF
--- a/scripts/e2e-templates/runner.js
+++ b/scripts/e2e-templates/runner.js
@@ -134,7 +134,10 @@ async function runTemplate(item, ctx) {
 
         // --ignore-workspace: the scaffolded project lives under the repo's tmp/, so pnpm would
         // otherwise pick up the monorepo workspace. We want a true standalone install from npm.
-        const installArgs = pm === 'pnpm' ? ['install', '--ignore-workspace'] : ['install'];
+        // A template that ships its own pnpm-workspace.yaml (build-script allowances) is already a
+        // standalone root, and the flag would discard that file along with the monorepo's.
+        const ownWorkspace = fs.existsSync(path.join(projectDir, 'pnpm-workspace.yaml'));
+        const installArgs = pm === 'pnpm' && !ownWorkspace ? ['install', '--ignore-workspace'] : ['install'];
         const install = await record('install', pm, installArgs, { cwd: projectDir, timeoutMs: TIMEOUTS.install });
         if (!install.ok) return done('fail', 'install failed');
 

--- a/tooling/create-app/package.json
+++ b/tooling/create-app/package.json
@@ -17,6 +17,7 @@
     ],
     "scripts": {
         "build-templates": "node scripts/build-templates.js",
+        "test": "node --test test/*.test.js",
         "prepublishOnly": "node scripts/build-templates.js"
     },
     "dependencies": {

--- a/tooling/create-app/scripts/build-templates.js
+++ b/tooling/create-app/scripts/build-templates.js
@@ -114,6 +114,13 @@ async function rewriteTemplate(dst, versionMap) {
     }
 }
 
+// pnpm refuses dependency build scripts unless the project's own pnpm-workspace.yaml allows them;
+// a scaffolded project has no workspace, so templates whose tooling needs them (wrangler: workerd,
+// esbuild) ship the allowance. The samples themselves inherit the monorepo's list.
+export function renderPnpmWorkspace(allowBuilds) {
+    return `allowBuilds:\n${allowBuilds.map((name) => `  ${name}: true\n`).join('')}`;
+}
+
 async function buildOne(entry, versionMap) {
     const src = path.join(REPO_ROOT, entry.source);
     const dst = path.join(TEMPLATES_DIR, entry.key);
@@ -121,6 +128,9 @@ async function buildOne(entry, versionMap) {
     await fsp.rm(dst, { recursive: true, force: true });
     await fsp.cp(src, dst, { recursive: true, filter: makeFilter(entry) });
     await rewriteTemplate(dst, versionMap);
+    if (entry.allowBuilds?.length) {
+        await fsp.writeFile(path.join(dst, 'pnpm-workspace.yaml'), renderPnpmWorkspace(entry.allowBuilds));
+    }
 }
 
 async function main() {
@@ -135,7 +145,9 @@ async function main() {
     process.stdout.write(`templates built: ${MANIFEST.length} (${TEMPLATES_DIR})\n`);
 }
 
-main().catch((err) => {
-    process.stderr.write(`build-templates failed: ${err.stack || err}\n`);
-    process.exit(1);
-});
+if (process.argv[1] && path.resolve(process.argv[1]) === fileURLToPath(import.meta.url)) {
+    main().catch((err) => {
+        process.stderr.write(`build-templates failed: ${err.stack || err}\n`);
+        process.exit(1);
+    });
+}

--- a/tooling/create-app/src/manifest.json
+++ b/tooling/create-app/src/manifest.json
@@ -1,14 +1,105 @@
 [
-  { "key": "web-vanilla",             "group": "Web",     "framework": null,           "label": "Vanilla",           "kind": "app", "source": "examples/web-vanilla" },
-  { "key": "web-react-rspack",        "group": "Web",     "framework": "React",        "label": "Rspack",            "kind": "app", "source": "examples/web-react-rspack" },
-  { "key": "web-react-vite",          "group": "Web",     "framework": "React",        "label": "Vite",              "kind": "app", "source": "examples/web-react-vite" },
-  { "key": "web-vue-vite",            "group": "Web",     "framework": "Vue",          "label": "Vite",              "kind": "app", "source": "examples/web-vue-vite" },
-  { "key": "web-svelte-vite",         "group": "Web",     "framework": "Svelte",       "label": "Vite",              "kind": "app", "source": "examples/web-svelte-vite" },
-  { "key": "mobile-reactnative-cli",  "group": "Mobile",  "framework": "React Native", "label": "Native CLI",        "kind": "app", "source": "examples/mobile-reactnative-cli", "nativeFolders": true },
-  { "key": "mobile-reactnative-expo", "group": "Mobile",  "framework": "React Native", "label": "Expo",              "kind": "app", "source": "examples/mobile-reactnative-expo", "nativeFolders": false, "keepLockfile": true },
-  { "key": "backend-nodejs-wasm",     "group": "Backend", "framework": "Node.js",      "label": "WebAssembly",       "kind": "app", "source": "examples/backend-nodejs-wasm" },
-  { "key": "cloud-cloudflare-worker", "group": "Cloud",   "framework": null,           "label": "Cloudflare Worker", "kind": "app", "source": "examples/cloud-cloudflare-worker" },
-  { "key": "lib-prebuilt",            "group": "Library", "framework": null,           "label": "Prebuilt",          "kind": "lib", "source": "examples/lib-prebuilt-matrix" },
-  { "key": "lib-source",              "group": "Library", "framework": null,           "label": "Source",            "kind": "lib", "source": "examples/lib-source" },
-  { "key": "lib-cmake",               "group": "Library", "framework": null,           "label": "CMake",             "kind": "lib", "source": "examples/lib-cmake" }
+    {
+        "key": "web-vanilla",
+        "group": "Web",
+        "framework": null,
+        "label": "Vanilla",
+        "kind": "app",
+        "source": "examples/web-vanilla"
+    },
+    {
+        "key": "web-react-rspack",
+        "group": "Web",
+        "framework": "React",
+        "label": "Rspack",
+        "kind": "app",
+        "source": "examples/web-react-rspack"
+    },
+    {
+        "key": "web-react-vite",
+        "group": "Web",
+        "framework": "React",
+        "label": "Vite",
+        "kind": "app",
+        "source": "examples/web-react-vite"
+    },
+    {
+        "key": "web-vue-vite",
+        "group": "Web",
+        "framework": "Vue",
+        "label": "Vite",
+        "kind": "app",
+        "source": "examples/web-vue-vite"
+    },
+    {
+        "key": "web-svelte-vite",
+        "group": "Web",
+        "framework": "Svelte",
+        "label": "Vite",
+        "kind": "app",
+        "source": "examples/web-svelte-vite"
+    },
+    {
+        "key": "mobile-reactnative-cli",
+        "group": "Mobile",
+        "framework": "React Native",
+        "label": "Native CLI",
+        "kind": "app",
+        "source": "examples/mobile-reactnative-cli",
+        "nativeFolders": true
+    },
+    {
+        "key": "mobile-reactnative-expo",
+        "group": "Mobile",
+        "framework": "React Native",
+        "label": "Expo",
+        "kind": "app",
+        "source": "examples/mobile-reactnative-expo",
+        "nativeFolders": false,
+        "keepLockfile": true
+    },
+    {
+        "key": "backend-nodejs-wasm",
+        "group": "Backend",
+        "framework": "Node.js",
+        "label": "WebAssembly",
+        "kind": "app",
+        "source": "examples/backend-nodejs-wasm"
+    },
+    {
+        "key": "cloud-cloudflare-worker",
+        "group": "Cloud",
+        "framework": null,
+        "label": "Cloudflare Worker",
+        "kind": "app",
+        "source": "examples/cloud-cloudflare-worker",
+        "allowBuilds": [
+            "esbuild",
+            "workerd"
+        ]
+    },
+    {
+        "key": "lib-prebuilt",
+        "group": "Library",
+        "framework": null,
+        "label": "Prebuilt",
+        "kind": "lib",
+        "source": "examples/lib-prebuilt-matrix"
+    },
+    {
+        "key": "lib-source",
+        "group": "Library",
+        "framework": null,
+        "label": "Source",
+        "kind": "lib",
+        "source": "examples/lib-source"
+    },
+    {
+        "key": "lib-cmake",
+        "group": "Library",
+        "framework": null,
+        "label": "CMake",
+        "kind": "lib",
+        "source": "examples/lib-cmake"
+    }
 ]

--- a/tooling/create-app/test/build-templates.test.js
+++ b/tooling/create-app/test/build-templates.test.js
@@ -1,0 +1,24 @@
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import path from 'node:path';
+import test from 'node:test';
+import { fileURLToPath } from 'node:url';
+import { renderPnpmWorkspace } from '../scripts/build-templates.js';
+
+const PKG_DIR = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const MANIFEST = JSON.parse(fs.readFileSync(path.join(PKG_DIR, 'src/manifest.json'), 'utf8'));
+
+test('templates that need dependency build scripts ship a pnpm allowBuilds file', () => {
+    const cloud = MANIFEST.find((entry) => entry.key === 'cloud-cloudflare-worker');
+    assert.deepEqual(cloud.allowBuilds, ['esbuild', 'workerd']);
+    const rendered = renderPnpmWorkspace(cloud.allowBuilds);
+    assert.match(rendered, /^allowBuilds:\n {2}esbuild: true\n {2}workerd: true\n$/m);
+    assert.doesNotMatch(rendered, /packages:/);
+});
+
+test('templates without build-script needs declare nothing', () => {
+    for (const entry of MANIFEST) {
+        if (entry.key === 'cloud-cloudflare-worker') continue;
+        assert.equal(entry.allowBuilds, undefined, `${entry.key} should not list allowBuilds`);
+    }
+});


### PR DESCRIPTION
pnpm refuses dependency build scripts unless the project's own pnpm-workspace.yaml allows them, and pnpm 11 turns the refusal into an error. A scaffolded Cloudflare Worker project therefore never got the workerd and esbuild binaries wrangler needs. Templates can now declare allowBuilds in the manifest; the generator writes the allowance file into the template, and the e2e runner stops passing --ignore-workspace to a project that ships its own workspace file, since the flag discarded it.