### PR TITLE
fix(release): publish even when a platform build was skipped

### DIFF
--- a/.github/workflows/release-crossbind.yml
+++ b/.github/workflows/release-crossbind.yml
@@ -239,7 +239,11 @@ jobs:
         needs:
             - plan
             - assemble
-        if: ${{ !inputs.dry_run && needs.plan.outputs.packageCount != '0' }}
+        # A train without macOS (or Linux) packages skips that build job; the status function keeps
+        # GitHub from applying success() over the whole chain and silently skipping publication.
+        if: >-
+            ${{ !cancelled() && !inputs.dry_run && needs.plan.result == 'success' && needs.assemble.result == 'success' &&
+            needs.plan.outputs.packageCount != '0' }}
         runs-on: ubuntu-24.04
         environment: npm-release
         permissions:

--- a/scripts/release/test/actionlint.test.mjs
+++ b/scripts/release/test/actionlint.test.mjs
@@ -201,3 +201,15 @@ test('the macOS sample workflows survive Dependabot runs and refuse React Native
     assert.match(ios, /MAESTRO_DRIVER_STARTUP_TIMEOUT: '\d{6}'/);
     assert.match(ios, /No prebuilt artifacts found\|\\\[Hermes\\\] Using the latest commit/);
 });
+
+test('the publish job still runs when a platform build was skipped', () => {
+    const source = fs.readFileSync(path.join(ROOT, '.github', 'workflows', 'release-crossbind.yml'), 'utf8');
+    const publish = source.slice(source.indexOf('\n    publish:\n'));
+    const condition = /if: >-\n\s+\$\{\{ (.*?) \}\}/s.exec(publish)?.[1] ?? '';
+    // A single-platform train skips the other platform's build job; without a status function GitHub
+    // applies success() over the whole dependency chain and skips publication silently.
+    assert.match(condition, /^!cancelled\(\) && !inputs\.dry_run/);
+    assert.match(condition, /needs\.plan\.result == 'success'/);
+    assert.match(condition, /needs\.assemble\.result == 'success'/);
+    assert.match(condition, /needs\.plan\.outputs\.packageCount != '0'/);
+});


### PR DESCRIPTION
A train with no macOS packages skips the iOS build job. The assemble job tolerated that, but the publish job's condition had no status function, so GitHub applied success() across the dependency chain and skipped publication silently; the create-crossbind beta 57 train ended green without publishing. Gate publication on the plan and assemble results explicitly.